### PR TITLE
Fixed handling empty guards on MultiAuthenticate middleware. Let Authenticate handle it

### DIFF
--- a/src/Guards/GuardChecker.php
+++ b/src/Guards/GuardChecker.php
@@ -2,9 +2,9 @@
 
 namespace SMartins\PassportMultiauth\Guards;
 
-use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
+use Illuminate\Support\Collection;
 
 class GuardChecker
 {

--- a/src/Guards/GuardChecker.php
+++ b/src/Guards/GuardChecker.php
@@ -2,6 +2,7 @@
 
 namespace SMartins\PassportMultiauth\Guards;
 
+use Illuminate\Support\Collection;
 use Illuminate\Support\Str;
 use Illuminate\Http\Request;
 
@@ -33,7 +34,7 @@ class GuardChecker
      * guard on value.
      *
      * @param  array $guards
-     * @return array
+     * @return Collection
      */
     public static function getGuardsProviders($guards)
     {

--- a/src/Http/Middleware/AddCustomProvider.php
+++ b/src/Http/Middleware/AddCustomProvider.php
@@ -8,7 +8,7 @@ use Illuminate\Http\Request;
 class AddCustomProvider
 {
     /**
-     * The default provder of api guard.
+     * The default provider of api guard.
      *
      * @var string
      */

--- a/src/Http/Middleware/MultiAuthenticate.php
+++ b/src/Http/Middleware/MultiAuthenticate.php
@@ -3,7 +3,6 @@
 namespace SMartins\PassportMultiauth\Http\Middleware;
 
 use Closure;
-use Illuminate\Http\Request;
 use League\OAuth2\Server\ResourceServer;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\Middleware\Authenticate;
@@ -29,17 +28,19 @@ class MultiAuthenticate extends Authenticate
     protected $providers;
 
     /**
-     * The authentication factory instance.
+     * Create a new middleware instance.
      *
-     * @var \Illuminate\Contracts\Auth\Factory
+     * @param ResourceServer $server
+     * @param ProviderRepository $providers
+     * @param Auth $auth
+     * @return void
      */
-    protected $auth;
-
     public function __construct(ResourceServer $server, ProviderRepository $providers, Auth $auth)
     {
+        parent::__construct($auth);
+
         $this->server = $server;
         $this->providers = $providers;
-        $this->auth = $auth;
     }
 
     /**
@@ -93,7 +94,7 @@ class MultiAuthenticate extends Authenticate
     /**
      * Check if user acting has the required guards and scopes on request.
      *
-     * @param  \Illuminate\Foundation\Auth\User $user
+     * @param Authenticatable $user
      * @param  array $guards
      * @return bool
      */
@@ -109,7 +110,7 @@ class MultiAuthenticate extends Authenticate
      *
      * @param \SMartins\PassportMultiauth\Provider $token
      * @param  array $guards
-     * @return void
+     * @return mixed
      *
      * @throws \Illuminate\Auth\AuthenticationException
      */

--- a/src/Http/Middleware/MultiAuthenticate.php
+++ b/src/Http/Middleware/MultiAuthenticate.php
@@ -57,7 +57,7 @@ class MultiAuthenticate extends Authenticate
     {
         // If don't has any guard follow the flow
         if (empty($guards)) {
-            return $next($request);
+            return $this->authenticate($guards);
         }
 
         $psrRequest = ServerRequest::createRequest($request);

--- a/src/Http/Middleware/MultiAuthenticate.php
+++ b/src/Http/Middleware/MultiAuthenticate.php
@@ -33,10 +33,12 @@ class MultiAuthenticate extends Authenticate
      * @param ResourceServer $server
      * @param ProviderRepository $providers
      * @param Auth $auth
-     * @return void
      */
-    public function __construct(ResourceServer $server, ProviderRepository $providers, Auth $auth)
-    {
+    public function __construct(
+        ResourceServer $server,
+        ProviderRepository $providers,
+        Auth $auth
+    ) {
         parent::__construct($auth);
 
         $this->server = $server;

--- a/src/PassportMultiauth.php
+++ b/src/PassportMultiauth.php
@@ -14,9 +14,10 @@ class PassportMultiauth
     /**
      * Set the current user for the application with the given scopes.
      *
-     * @param  \Illuminate\Contracts\Auth\Authenticatable  $user
-     * @param  array  $scopes
+     * @param  \Illuminate\Contracts\Auth\Authenticatable $user
+     * @param  array $scopes
      * @return void
+     * @throws Exception
      */
     public static function actingAs($user, $scopes = [])
     {

--- a/tests/Feature/MultiauthTest.php
+++ b/tests/Feature/MultiauthTest.php
@@ -47,6 +47,17 @@ class MultiauthTest extends TestCase
         Route::middleware('auth:api,company')->get('/users', function (Request $request) {
             return get_class($request->user());
         });
+
+        Route::middleware('auth')->get('/no_guards', function (Request $request) {
+            return $request->user();
+        });
+    }
+
+    public function testAuthenticateOnRouteWithoutGuardsWithInvalidToken()
+    {
+        $response = $this->json('GET', 'no_guards', [], ['Authorization' => 'Bearer token']);
+
+        $this->assertInstanceOf(AuthenticationException::class, $response->exception);
     }
 
     public function testGetLoggedUserAsUser()

--- a/tests/Fixtures/Http/Kernel.php
+++ b/tests/Fixtures/Http/Kernel.php
@@ -3,6 +3,7 @@
 namespace SMartins\PassportMultiauth\Tests\Fixtures\Http;
 
 use Orchestra\Testbench\Http\Kernel as HttpKernel;
+use Orchestra\Testbench\Http\Middleware\RedirectIfAuthenticated;
 
 class Kernel extends HttpKernel
 {
@@ -19,7 +20,7 @@ class Kernel extends HttpKernel
         'auth.basic' => \Illuminate\Auth\Middleware\AuthenticateWithBasicAuth::class,
         'bindings' => \Illuminate\Routing\Middleware\SubstituteBindings::class,
         'can' => \Illuminate\Auth\Middleware\Authorize::class,
-        'guest' => Middleware\RedirectIfAuthenticated::class,
+        'guest' => RedirectIfAuthenticated::class,
         'throttle' => \Illuminate\Routing\Middleware\ThrottleRequests::class,
     ];
 }

--- a/tests/Unit/MultiAuthenticateMiddlewareTest.php
+++ b/tests/Unit/MultiAuthenticateMiddlewareTest.php
@@ -39,6 +39,8 @@ class MultiAuthenticateMiddlewareTest extends TestCase
 
     public function testTryAuthWithoutGuards()
     {
+        $this->expectException(AuthenticationException::class);
+
         $resourceServer = Mockery::mock('League\OAuth2\Server\ResourceServer');
 
         $repository = Mockery::mock('SMartins\PassportMultiauth\ProviderRepository');
@@ -46,11 +48,9 @@ class MultiAuthenticateMiddlewareTest extends TestCase
         $request = $this->createRequest();
 
         $middleware = new MultiAuthenticate($resourceServer, $repository, $this->auth);
-        $response = $middleware->handle($request, function () {
+        $middleware->handle($request, function () {
             return 'response';
         });
-
-        $this->assertEquals('response', $response);
     }
 
     public function testTryAuthWithoutAccessTokenId()


### PR DESCRIPTION
Closes #34 