### PR TITLE
Fixed error returning request without guards

### DIFF
--- a/src/Http/Middleware/MultiAuthenticate.php
+++ b/src/Http/Middleware/MultiAuthenticate.php
@@ -60,7 +60,9 @@ class MultiAuthenticate extends Authenticate
     {
         // If don't has any guard follow the flow
         if (empty($guards)) {
-            return $this->authenticate($guards);
+            $this->authenticate($guards);
+            
+            return $next($request);
         }
 
         $psrRequest = ServerRequest::createRequest($request);

--- a/src/Http/Middleware/MultiAuthenticate.php
+++ b/src/Http/Middleware/MultiAuthenticate.php
@@ -61,7 +61,7 @@ class MultiAuthenticate extends Authenticate
         // If don't has any guard follow the flow
         if (empty($guards)) {
             $this->authenticate($guards);
-            
+        // stop laravel from checking for a token if session is not set 
             return $next($request);
         }
 

--- a/src/Http/Middleware/MultiAuthenticate.php
+++ b/src/Http/Middleware/MultiAuthenticate.php
@@ -59,9 +59,9 @@ class MultiAuthenticate extends Authenticate
     public function handle($request, Closure $next, ...$guards)
     {
         // If don't has any guard follow the flow
+        // stop laravel from checking for a token if session is not set
         if (empty($guards)) {
             $this->authenticate($guards);
-        // stop laravel from checking for a token if session is not set 
             return $next($request);
         }
 


### PR DESCRIPTION
As discussed earlier, this is a fix for` Symfony \ Component \ Debug \ Exception \ FatalThrowableError (E_ERROR) Call to a member function setCookie() on null`

For your information, i also use the @jumeni account at work... 