### PR TITLE
Block the request to issue new tokens if an invalid provider is given.

### DIFF
--- a/src/Http/Middleware/AddCustomProvider.php
+++ b/src/Http/Middleware/AddCustomProvider.php
@@ -76,6 +76,6 @@ class AddCustomProvider
             }
         }
 
-        return false;
+        return true;
     }
 }

--- a/src/Http/Middleware/AddCustomProvider.php
+++ b/src/Http/Middleware/AddCustomProvider.php
@@ -4,6 +4,7 @@ namespace SMartins\PassportMultiauth\Http\Middleware;
 
 use Closure;
 use Illuminate\Http\Request;
+use League\OAuth2\Server\Exception\OAuthServerException;
 
 class AddCustomProvider
 {
@@ -20,20 +21,24 @@ class AddCustomProvider
      * is used by Laravel Passport to get the correct model on access token
      * creation.
      *
-     * @param  \Illuminate\Http\Request  $request
-     * @param  \Closure  $next
+     * @param  \Illuminate\Http\Request $request
+     * @param  \Closure $next
+     *
      * @return mixed
+     *
+     * @throws OAuthServerException
      */
     public function handle(Request $request, Closure $next)
     {
         $this->defaultApiProvider = config('auth.guards.api.provider');
 
-        $params = $request->all();
-        if (array_key_exists('provider', $params)) {
-            if (! is_null($params['provider'])) {
-                config(['auth.guards.api.provider' => $params['provider']]);
-            }
+        $provider = $request->get('provider');
+
+        if ($this->invalidProvider($provider)) {
+            throw OAuthServerException::invalidRequest('provider');
         }
+
+        config(['auth.guards.api.provider' => $provider]);
 
         return $next($request);
     }
@@ -50,5 +55,27 @@ class AddCustomProvider
     public function terminate()
     {
         config(['auth.guards.api.provider' => $this->defaultApiProvider]);
+    }
+
+    /**
+     * Check if the given provider is not registered in the auth configuration file.
+     *
+     * @param $provider
+     *
+     * @return bool
+     */
+    protected function invalidProvider($provider)
+    {
+        if (is_null($provider)) {
+            return true;
+        }
+
+        foreach (config('auth.guards') as $guardsConfiguration) {
+            if ($guardsConfiguration['provider'] === $provider) {
+                return false;
+            }
+        }
+
+        return false;
     }
 }

--- a/tests/Unit/AddCustomProviderTest.php
+++ b/tests/Unit/AddCustomProviderTest.php
@@ -2,10 +2,10 @@
 
 namespace SMartins\PassportMultiauth\Tests\Unit;
 
-use League\OAuth2\Server\Exception\OAuthServerException;
 use Mockery;
 use Illuminate\Http\Request;
 use SMartins\PassportMultiauth\Tests\TestCase;
+use League\OAuth2\Server\Exception\OAuthServerException;
 use SMartins\PassportMultiauth\Http\Middleware\AddCustomProvider;
 
 class AddCustomProviderTest extends TestCase

--- a/tests/Unit/AddCustomProviderTest.php
+++ b/tests/Unit/AddCustomProviderTest.php
@@ -25,9 +25,7 @@ class AddCustomProviderTest extends TestCase
     public function testIfApiProviderOnAuthWasSetCorrectly()
     {
         $request = Mockery::mock(Request::class);
-        $request->shouldReceive('all')->andReturn([
-            'provider' => 'companies',
-        ]);
+        $request->shouldReceive('get')->andReturn('companies')->with('provider');
 
         $middleware = new AddCustomProvider();
         $middleware->handle($request, function () {


### PR DESCRIPTION
This PR adds an early protection in the AddCustomProvider middleware by checking that the provider given in the request is registered in the auth configuration, if not it will throw an exception to block the request also if the request is missing the provider param it will block it.