### PR TITLE
Fixed error getting two different instance using same token

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -10,4 +10,5 @@
 .travis.yml export-ignore
 CONTRIBUTING.md export-ignore
 phpunit.xml export-ignore
+phpunit.xml.dist export-ignore
 UPGRADE.md export-ignore

--- a/.gitignore
+++ b/.gitignore
@@ -4,3 +4,4 @@
 /.phpintel
 /.vscode
 composer.lock
+.phpunit.result.cache

--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,4 @@
 /.idea
 /.phpintel
 /.vscode
-.composer.lock
+composer.lock

--- a/README.md
+++ b/README.md
@@ -39,13 +39,39 @@ Install using composer:
 $ composer require smartins/passport-multiauth
 ```
 
-If you are using a Laravel version **less than 5.5** you **need to add** the provider on `config/app.php`:
+To all works fine, we need to ensure that the `SMartins\PassportMultiauth\Providers\MultiauthServiceProvider::class` service provider
+be registered before `Laravel\Passport\PassportServiceProvider::class`.
+
+Firstly, you will remove the `laravel/passport` package from Laravel [Package Discovery](https://laravel.com/docs/5.8/packages#package-discovery).
+
+In your `composer.json` file, add the `laravel/passport` to `extra.laravel.dont-discover` array:
+
+```json
+    "extra": {
+        "laravel": {
+            "dont-discover": [
+                "laravel/passport"
+            ]
+        }
+    },
+```
+
+And register the providers manually on `config/app.php`:
 
 ```php
     'providers' => [
         // ...
         SMartins\PassportMultiauth\Providers\MultiauthServiceProvider::class,
+        Laravel\Passport\PassportServiceProvider::class,
     ],
+```
+
+**WARNING:** The provider `SMartins\PassportMultiauth\Providers\MultiauthServiceProvider::class` MUST be added before `Laravel\Passport\PassportServiceProvider::class` to it works fine.
+
+Maybe you will need clear the bootstrap cache files to re-register the providers:
+
+```sh
+php artisan optimize:clear
 ```
 
 Migrate database to create `oauth_access_token_providers` table:
@@ -54,7 +80,14 @@ Migrate database to create `oauth_access_token_providers` table:
 $ php artisan migrate
 ```
 
+**NOTE** If you don't ron the command to install passport run:
+
+```sh
+$ php artisan passport:install
+``` 
+
 Instead use the `Laravel\Passport\HasApiTokens` trait from [Laravel Passport](https://laravel.com/docs/5.6/passport#installation) core, use the trait `SMartins\PassportMultiauth\HasMultiAuthApiTokens`. 
+
 Internally, this `HasMultiAuthApiTokens` uses the `HasApiTokens`, overriding the methods `tokens()` and `createToken($name, $scopes = [])`. 
 The behavior of the method `tokens()` was changed to join with the table `oauth_access_token_providers` getting just the tokens created
 to specific model. 

--- a/composer.json
+++ b/composer.json
@@ -37,12 +37,6 @@
     "extra": {
         "branch-alias": {
             "dev-master": "4.0-dev"
-        },
-        "laravel": {
-            "providers": [
-                "SMartins\\PassportMultiauth\\Providers\\MultiauthServiceProvider"
-            ]
         }
     }
-
 }

--- a/src/Auth/AuthManager.php
+++ b/src/Auth/AuthManager.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace SMartins\PassportMultiauth\Auth;
+
+use Illuminate\Auth\AuthManager as BaseAuthManager;
+
+class AuthManager extends BaseAuthManager
+{
+    /**
+     * Clear guards cache to resolve it again.
+     */
+    public function clearGuardsCache()
+    {
+        $this->guards = [];
+    }
+}

--- a/src/Config/AuthConfigHelper.php
+++ b/src/Config/AuthConfigHelper.php
@@ -29,11 +29,10 @@ class AuthConfigHelper
      * Get the guard of specific provider to `passport` driver.
      *
      * @param  string $provider
-     * @param Authenticatable $user
      * @return string
      * @throws MissingConfigException
      */
-    public static function getProviderGuard($provider, Authenticatable $user)
+    public static function getProviderGuard($provider)
     {
         foreach (config('auth.guards') as $guard => $content) {
             if ($content['driver'] == 'passport' && $content['provider'] == $provider) {
@@ -41,7 +40,7 @@ class AuthConfigHelper
             }
         }
 
-        throw MissingConfigException::guard($user);
+        throw MissingConfigException::providerGuard($provider);
     }
 
     /**
@@ -55,6 +54,17 @@ class AuthConfigHelper
     {
         $provider = self::getUserProvider($user);
 
-        return self::getProviderGuard($provider, $user);
+        return self::getProviderGuard($provider);
+    }
+
+    /**
+     * @param string $provider
+     * @return null|Illuminate\Database\Eloquent\Model
+     */
+    public static function getProviderModel($provider)
+    {
+        $model = config('auth.providers.'.$provider.'.model', null);
+
+        return $model ? $model : null;
     }
 }

--- a/src/Exceptions/MissingConfigException.php
+++ b/src/Exceptions/MissingConfigException.php
@@ -18,15 +18,14 @@ class MissingConfigException extends Exception
     }
 
     /**
-     * @param Authenticatable $model
-     * @param string $driver
+     * @param $provider
      * @return MissingConfigException
      */
-    public static function guard(Authenticatable $model, $driver = 'passport')
+    public static function providerGuard($provider)
     {
-        $message = 'Any guard with driver "'.$driver.'" found to '.get_class($model);
+        $msg = 'Any guard found for provider '.$provider.' and driver passport';
 
-        return new static($message);
+        return new static($msg);
     }
 
     /**

--- a/src/Http/Middleware/MultiAuthenticate.php
+++ b/src/Http/Middleware/MultiAuthenticate.php
@@ -98,10 +98,9 @@ class MultiAuthenticate extends Authenticate
                 // default user will be returned.
                 // If has the guard on guards passed on middleware and the model
                 // instance are the same on an guard.
-                if (!$guard || (isset($guardsModels[$guard]) && $user instanceof $guardsModels[$guard])) {
+                if (! $guard || (isset($guardsModels[$guard]) && $user instanceof $guardsModels[$guard])) {
                     return $user;
                 }
-                return null;
             });
 
             // After it, we'll change the passport driver behavior to get the
@@ -111,6 +110,7 @@ class MultiAuthenticate extends Authenticate
                 'passport',
                 function ($app, $name, array $config) use ($request, $guards) {
                     $providerGuard = AuthConfigHelper::getProviderGuard($config['provider']);
+
                     return tap($this->makeGuard($request, $providerGuard), function ($guard) {
                         Application::getInstance()->refresh('request', $guard, 'setRequest');
                     });
@@ -186,6 +186,7 @@ class MultiAuthenticate extends Authenticate
             return $request->user($guard);
         }, $request);
     }
+
     /**
      * Get models from guards. It'll return an associative array where the keys
      * are the guards and the values are the correspondent models.
@@ -200,6 +201,7 @@ class MultiAuthenticate extends Authenticate
             $provider = GuardChecker::defaultGuardProvider($guard);
             $guardsModels[$guard] = AuthConfigHelper::getProviderModel($provider);
         }
+
         return $guardsModels;
     }
 }

--- a/src/Http/Middleware/MultiAuthenticate.php
+++ b/src/Http/Middleware/MultiAuthenticate.php
@@ -3,6 +3,8 @@
 namespace SMartins\PassportMultiauth\Http\Middleware;
 
 use Closure;
+use Illuminate\Auth\RequestGuard;
+use Illuminate\Foundation\Application;
 use League\OAuth2\Server\ResourceServer;
 use Illuminate\Auth\AuthenticationException;
 use Illuminate\Auth\Middleware\Authenticate;
@@ -11,6 +13,7 @@ use Illuminate\Contracts\Auth\Authenticatable;
 use Illuminate\Contracts\Auth\Factory as Auth;
 use SMartins\PassportMultiauth\PassportMultiauth;
 use SMartins\PassportMultiauth\Provider as Token;
+use Illuminate\Support\Facades\Auth as AuthFacade;
 use SMartins\PassportMultiauth\ProviderRepository;
 use SMartins\PassportMultiauth\Guards\GuardChecker;
 use SMartins\PassportMultiauth\Facades\ServerRequest;
@@ -80,7 +83,39 @@ class MultiAuthenticate extends Authenticate
 
             $guard = $this->getTokenGuard($accessToken, $guards);
 
+            // At this point, the authentication will be done by Laravel Passport default driver.
             $this->authenticate($request, $guard);
+
+            $guardsModels = $this->getGuardsModels($guards);
+
+            // The laravel passport will define the logged user on request.
+            // The returned model can be anywhere, depending on the guard.
+            $user = $request->user();
+
+            // But we need check if the user logged has the correct guard.
+            $request->setUserResolver(function ($guard) use ($user, $guardsModels) {
+                // If don't exists any guard on $request->user() parameter, the
+                // default user will be returned.
+                // If has the guard on guards passed on middleware and the model
+                // instance are the same on an guard.
+                if (!$guard || (isset($guardsModels[$guard]) && $user instanceof $guardsModels[$guard])) {
+                    return $user;
+                }
+                return null;
+            });
+
+            // After it, we'll change the passport driver behavior to get the
+            // authenticated user. It'll change on methods like Auth::user(),
+            // Auth::guard('company')-user(), Auth::check().
+            AuthFacade::extend(
+                'passport',
+                function ($app, $name, array $config) use ($request, $guards) {
+                    $providerGuard = AuthConfigHelper::getProviderGuard($config['provider']);
+                    return tap($this->makeGuard($request, $providerGuard), function ($guard) {
+                        Application::getInstance()->refresh('request', $guard, 'setRequest');
+                    });
+                }
+            );
         } catch (OAuthServerException $e) {
             // If has an OAuthServerException check if has unit tests and fake
             // user authenticated.
@@ -138,5 +173,33 @@ class MultiAuthenticate extends Authenticate
 
         // use only guard associated to access token provider
         return $providers->has($token->provider) ? [$providers->get($token->provider)] : [];
+    }
+
+    /**
+     * @param \Illuminate\Http\Request $request
+     * @param string $guard
+     * @return RequestGuard
+     */
+    private function makeGuard($request, $guard)
+    {
+        return new RequestGuard(function ($request) use ($guard) {
+            return $request->user($guard);
+        }, $request);
+    }
+    /**
+     * Get models from guards. It'll return an associative array where the keys
+     * are the guards and the values are the correspondent models.
+     *
+     * @param array $guards
+     * @return array
+     */
+    private function getGuardsModels(array $guards)
+    {
+        $guardsModels = [];
+        foreach ($guards as $guard) {
+            $provider = GuardChecker::defaultGuardProvider($guard);
+            $guardsModels[$guard] = AuthConfigHelper::getProviderModel($provider);
+        }
+        return $guardsModels;
     }
 }

--- a/src/Providers/MultiauthServiceProvider.php
+++ b/src/Providers/MultiauthServiceProvider.php
@@ -2,16 +2,19 @@
 
 namespace SMartins\PassportMultiauth\Providers;
 
+use Illuminate\Auth\AuthServiceProvider;
 use Illuminate\Support\Facades\Event;
-use Illuminate\Support\ServiceProvider;
 use Laravel\Passport\Events\AccessTokenCreated;
+use SMartins\PassportMultiauth\Auth\AuthManager;
+use SMartins\PassportMultiauth\Http\Middleware\AddCustomProvider;
 use SMartins\PassportMultiauth\ProviderRepository;
 
-class MultiauthServiceProvider extends ServiceProvider
+class MultiauthServiceProvider extends AuthServiceProvider
 {
     /**
      * Bootstrap any application services.
      *
+     * @param ProviderRepository $providers
      * @return void
      */
     public function boot(ProviderRepository $providers)
@@ -24,7 +27,7 @@ class MultiauthServiceProvider extends ServiceProvider
 
         // Register the middleware as singleton to use the same middleware
         // instance when the handle and terminate methods are called.
-        $this->app->singleton(\SMartins\PassportMultiauth\Http\Middleware\AddCustomProvider::class);
+        $this->app->singleton(AddCustomProvider::class);
     }
 
     /**
@@ -42,6 +45,27 @@ class MultiauthServiceProvider extends ServiceProvider
             [$migrationsPath => database_path('migrations')],
             'migrations'
         );
+    }
+
+    /**
+     * Register the authenticator services.
+     *
+     * @return void
+     */
+    protected function registerAuthenticator()
+    {
+        $this->app->singleton('auth', function ($app) {
+            // Once the authentication service has actually been requested by the developer
+            // we will set a variable in the application indicating such. This helps us
+            // know that we need to set any queued cookies in the after event later.
+            $app['auth.loaded'] = true;
+
+            return new AuthManager($app);
+        });
+
+        $this->app->singleton('auth.driver', function ($app) {
+            return $app['auth']->guard();
+        });
     }
 
     /**

--- a/tests/Feature/MultiauthTest.php
+++ b/tests/Feature/MultiauthTest.php
@@ -4,15 +4,15 @@ namespace SMartins\PassportMultiauth\Tests\Feature;
 
 use Illuminate\Http\Request;
 use Laravel\Passport\Client;
+use Laravel\Passport\Passport;
 use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Auth\AuthenticationException;
-use Laravel\Passport\Passport;
-use SMartins\PassportMultiauth\Http\Middleware\AddCustomProvider;
 use SMartins\PassportMultiauth\Tests\TestCase;
 use SMartins\PassportMultiauth\PassportMultiauth;
 use SMartins\PassportMultiauth\Tests\Fixtures\Models\User;
 use SMartins\PassportMultiauth\Tests\Fixtures\Models\Company;
+use SMartins\PassportMultiauth\Http\Middleware\AddCustomProvider;
 
 class MultiauthTest extends TestCase
 {
@@ -65,7 +65,7 @@ class MultiauthTest extends TestCase
                 Auth::guard('api')->user(),
                 Auth::guard('company')->user(),
                 Auth::check(),
-                Auth::id()
+                Auth::id(),
             ];
         });
 
@@ -78,7 +78,7 @@ class MultiauthTest extends TestCase
                 Auth::guard('api')->user(),
                 Auth::guard('company')->user(),
                 Auth::check(),
-                Auth::id()
+                Auth::id(),
             ];
         });
 
@@ -91,7 +91,7 @@ class MultiauthTest extends TestCase
                 Auth::guard('api')->user(),
                 Auth::guard('company')->user(),
                 Auth::check(),
-                Auth::id()
+                Auth::id(),
             ];
         });
 

--- a/tests/Feature/MultiauthTest.php
+++ b/tests/Feature/MultiauthTest.php
@@ -3,8 +3,12 @@
 namespace SMartins\PassportMultiauth\Tests\Feature;
 
 use Illuminate\Http\Request;
+use Laravel\Passport\Client;
+use Illuminate\Support\Facades\Auth;
 use Illuminate\Support\Facades\Route;
 use Illuminate\Auth\AuthenticationException;
+use Laravel\Passport\Passport;
+use SMartins\PassportMultiauth\Http\Middleware\AddCustomProvider;
 use SMartins\PassportMultiauth\Tests\TestCase;
 use SMartins\PassportMultiauth\PassportMultiauth;
 use SMartins\PassportMultiauth\Tests\Fixtures\Models\User;
@@ -19,6 +23,8 @@ class MultiauthTest extends TestCase
         $this->loadLaravelMigrations(['--database' => 'passport']);
 
         $this->artisan('migrate');
+
+        $this->artisan('key:generate');
 
         $this->artisan('passport:install');
 
@@ -36,6 +42,12 @@ class MultiauthTest extends TestCase
      */
     public function setUpRoutes()
     {
+        Route::group(['middleware' => AddCustomProvider::class], function () {
+            Passport::routes(function ($router) {
+                return $router->forAccessTokens();
+            });
+        });
+
         Route::middleware('auth:api')->get('/user', function (Request $request) {
             return $request->user();
         });
@@ -45,7 +57,42 @@ class MultiauthTest extends TestCase
         });
 
         Route::middleware('auth:api,company')->get('/users', function (Request $request) {
-            return get_class($request->user());
+            return [
+                $request->user('api'),
+                $request->user('company'),
+                $request->user(),
+                Auth::user(),
+                Auth::guard('api')->user(),
+                Auth::guard('company')->user(),
+                Auth::check(),
+                Auth::id()
+            ];
+        });
+
+        Route::middleware('auth:api')->get('/just_user', function (Request $request) {
+            return [
+                $request->user('api'),
+                $request->user('company'),
+                $request->user(),
+                Auth::user(),
+                Auth::guard('api')->user(),
+                Auth::guard('company')->user(),
+                Auth::check(),
+                Auth::id()
+            ];
+        });
+
+        Route::middleware('auth:company')->get('/just_company', function (Request $request) {
+            return [
+                $request->user('api'),
+                $request->user('company'),
+                $request->user(),
+                Auth::user(),
+                Auth::guard('api')->user(),
+                Auth::guard('company')->user(),
+                Auth::check(),
+                Auth::id()
+            ];
         });
 
         Route::middleware('auth')->get('/no_guards', function (Request $request) {
@@ -53,20 +100,171 @@ class MultiauthTest extends TestCase
         });
     }
 
+    /**
+     * @test
+     */
+    public function it_will_return_user_instance_just_with_correct_guard()
+    {
+        // Two different models with same id.
+        $user = factory(User::class)->create();
+        factory(Company::class)->create();
+
+        $client = (new Client())
+            ->where(['password_client' => 1, 'revoked' => 0])
+            ->first();
+
+        $params = [
+            'grant_type' => 'password',
+            'username' => $user->email,
+            'password' => 'secret',
+            'client_id' => $client->id,
+            'client_secret' => $client->secret,
+            'provider' => 'users',
+        ];
+
+        $response = $this->json('POST', '/oauth/token', $params);
+
+        $accessToken = json_decode($response->getContent(), true)['access_token'];
+
+        $response = $this->json('GET', '/just_user', [], ['Authorization' => 'Bearer '.$accessToken]);
+
+        $original = $response->getOriginalContent();
+
+        $this->assertInstanceOf(User::class, $original[0]);
+        $this->assertNull($original[1]);
+        $this->assertInstanceOf(User::class, $original[2]);
+        $this->assertInstanceOf(User::class, $original[3]);
+        $this->assertInstanceOf(User::class, $original[4]);
+        $this->assertNull($original[5]);
+        $this->assertTrue($original[6]);
+        $this->assertEquals($user->id, $original[7]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_return_company_instance_just_with_correct_guard()
+    {
+        // Two different models with same id.
+        factory(User::class)->create();
+        $company = factory(Company::class)->create();
+
+        $client = (new Client())
+            ->where(['password_client' => 1, 'revoked' => 0])
+            ->first();
+
+        $params = [
+            'grant_type' => 'password',
+            'username' => $company->email,
+            'password' => 'secret',
+            'client_id' => $client->id,
+            'client_secret' => $client->secret,
+            'provider' => 'companies',
+        ];
+
+        $response = $this->json('POST', '/oauth/token', $params);
+
+        $accessToken = json_decode($response->getContent(), true)['access_token'];
+
+        $response = $this->json('GET', '/just_company', [], ['Authorization' => 'Bearer '.$accessToken]);
+
+        $original = $response->getOriginalContent();
+
+        $this->assertNull($original[0]);
+        $this->assertInstanceOf(Company::class, $original[1]);
+        $this->assertInstanceOf(Company::class, $original[2]);
+        $this->assertInstanceOf(Company::class, $original[3]);
+        $this->assertNull($original[4]);
+        $this->assertInstanceOf(Company::class, $original[5]);
+        $this->assertTrue($original[6]);
+        $this->assertEquals($company->id, $original[7]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_return_ways_to_get_user_logged_as_user_on_multi_guards_route()
+    {
+        // Two different models with same id.
+        $user = factory(User::class)->create();
+        factory(Company::class)->create();
+
+        $client = (new Client())
+            ->where(['password_client' => 1, 'revoked' => 0])
+            ->first();
+
+        $params = [
+            'grant_type' => 'password',
+            'username' => $user->email,
+            'password' => 'secret',
+            'client_id' => $client->id,
+            'client_secret' => $client->secret,
+            'provider' => 'users',
+        ];
+
+        $response = $this->json('POST', '/oauth/token', $params);
+
+        $accessToken = json_decode($response->getContent(), true)['access_token'];
+
+        $response = $this->json('GET', '/users', [], ['Authorization' => 'Bearer '.$accessToken]);
+
+        $original = $response->getOriginalContent();
+
+        $this->assertInstanceOf(User::class, $original[0]);
+        $this->assertNull($original[1]);
+        $this->assertInstanceOf(User::class, $original[2]);
+        $this->assertInstanceOf(User::class, $original[3]);
+        $this->assertInstanceOf(User::class, $original[4]);
+        $this->assertNull($original[5]);
+        $this->assertTrue($original[6]);
+        $this->assertEquals($user->id, $original[7]);
+    }
+
+    /**
+     * @test
+     */
+    public function it_will_return_ways_to_get_user_logged_as_company_on_multi_guards_route()
+    {
+        // Two different models with same id.
+        factory(User::class)->create();
+        $company = factory(Company::class)->create();
+
+        $client = (new Client())
+            ->where(['password_client' => 1, 'revoked' => 0])
+            ->first();
+
+        $params = [
+            'grant_type' => 'password',
+            'username' => $company->email,
+            'password' => 'secret',
+            'client_id' => $client->id,
+            'client_secret' => $client->secret,
+            'provider' => 'companies',
+        ];
+
+        $response = $this->json('POST', '/oauth/token', $params);
+
+        $accessToken = json_decode($response->getContent(), true)['access_token'];
+
+        $response = $this->json('GET', '/users', [], ['Authorization' => 'Bearer '.$accessToken]);
+
+        $original = $response->getOriginalContent();
+
+        $this->assertNull($original[0]);
+        $this->assertInstanceOf(Company::class, $original[1]);
+        $this->assertInstanceOf(Company::class, $original[2]);
+        $this->assertInstanceOf(Company::class, $original[3]);
+        $this->assertNull($original[4]);
+        $this->assertInstanceOf(Company::class, $original[5]);
+        $this->assertTrue($original[6]);
+        $this->assertEquals($company->id, $original[7]);
+    }
+
     public function testAuthenticateOnRouteWithoutGuardsWithInvalidToken()
     {
         $response = $this->json('GET', 'no_guards', [], ['Authorization' => 'Bearer token']);
 
         $this->assertInstanceOf(AuthenticationException::class, $response->exception);
-    }
-
-    public function testGetLoggedUserAsUser()
-    {
-        $user = factory(User::class)->create();
-
-        $response = $this->sendRequest('GET', 'user', $user);
-
-        $this->assertInstanceOf(User::class, $response->original);
     }
 
     public function testGetLoggedUserAsCompany()
@@ -78,15 +276,6 @@ class MultiauthTest extends TestCase
         $this->assertInstanceOf(AuthenticationException::class, $response->exception);
     }
 
-    public function testGetLoggedCompanyAsCompany()
-    {
-        $company = factory(Company::class)->create();
-
-        $response = $this->sendRequest('GET', 'company', $company);
-
-        $this->assertInstanceOf(Company::class, $response->original);
-    }
-
     public function testGetLoggedCompanyAsUser()
     {
         $user = factory(User::class)->create();
@@ -96,24 +285,6 @@ class MultiauthTest extends TestCase
         $this->assertInstanceOf(AuthenticationException::class, $response->exception);
     }
 
-    public function testGetLoggedUserTypeAsCompany()
-    {
-        $company = factory(Company::class)->create();
-
-        $response = $this->sendRequest('GET', 'users', $company);
-
-        $this->assertEquals(Company::class, $response->original);
-    }
-
-    public function testGetLoggedUserTypeAsUser()
-    {
-        $user = factory(User::class)->create();
-
-        $response = $this->sendRequest('GET', 'users', $user);
-
-        $this->assertEquals(User::class, $response->original);
-    }
-
     /**
      * Send request to route with user to be authenticated.
      *
@@ -121,6 +292,7 @@ class MultiauthTest extends TestCase
      * @param  string $uri
      * @param  \Illuminate\Foundation\Auth\User $user
      * @return \Illuminate\Foundation\Testing\TestResponse
+     * @throws \Exception
      */
     public function sendRequest($method, $uri, $user, $scopes = [])
     {

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -23,8 +23,8 @@ abstract class TestCase extends BaseTestCase
     protected function getPackageProviders($app)
     {
         return [
-            PassportServiceProvider::class,
             MultiauthServiceProvider::class,
+            PassportServiceProvider::class,
             ConsoleServiceProvider::class,
         ];
     }
@@ -68,6 +68,7 @@ abstract class TestCase extends BaseTestCase
     protected function setAuthConfigs()
     {
         // Set up default entity
+        config(['auth.defaults.guard' => 'company']);
         config(['auth.guards.api.driver' => 'passport']);
         config(['auth.guards.api.provider' => 'users']);
         config(['auth.providers.users.model' => User::class]);

--- a/tests/Unit/AuthConfigHelperTest.php
+++ b/tests/Unit/AuthConfigHelperTest.php
@@ -20,7 +20,7 @@ class AuthConfigHelperTest extends TestCase
 
     public function testGetProviderGuard()
     {
-        $guard = AuthConfigHelper::getProviderGuard('companies', new Company);
+        $guard = AuthConfigHelper::getProviderGuard('companies');
 
         $this->assertEquals('company', $guard);
     }
@@ -28,7 +28,7 @@ class AuthConfigHelperTest extends TestCase
     public function testGetProviderGuardWithNotPassportDriver()
     {
         $this->expectException(MissingConfigException::class);
-        $this->expectExceptionMessage('Any guard with driver "passport" found to '.Customer::class.'. Please, check your config/auth.php file.');
+        $this->expectExceptionMessage('Any guard found for provider customers and driver passport');
 
         config(['auth.guards.customer.driver' => 'token']);
         config(['auth.guards.customer.provider' => 'customers']);
@@ -36,7 +36,7 @@ class AuthConfigHelperTest extends TestCase
         config(['auth.providers.customers.driver' => 'eloquent']);
         config(['auth.providers.customers.model' => Customer::class]);
 
-        AuthConfigHelper::getProviderGuard('customers', new Customer);
+        AuthConfigHelper::getProviderGuard('customers');
     }
 
     public function testGetUserGuard()


### PR DESCRIPTION
Fix #63 
Probably fix #51 
It extends the `Auth` to driver `passport` after Laravel Passport authenticate the users and check whats the correct user to be logged, based on guards passed on middleware.
The user resolver on request too was changed to check the correct logged user.