### PR TITLE
it sends by default the provider users, in case of not sending the pr…

### DIFF
--- a/src/Http/Middleware/AddCustomProvider.php
+++ b/src/Http/Middleware/AddCustomProvider.php
@@ -32,7 +32,7 @@ class AddCustomProvider
     {
         $this->defaultApiProvider = config('auth.guards.api.provider');
 
-        $provider = $request->get('provider');
+        $provider = $request->get('provider', 'users');
 
         if ($this->invalidProvider($provider)) {
             throw OAuthServerException::invalidRequest('provider');


### PR DESCRIPTION
it sends by default the provider users, in case of not sending the provider in the request of the oauth token, to avoid the error (The request is missing a required parameter, includes an invalid parameter value, includes a parameter more than once, or is otherwise malformed .)