### PR TITLE
Fixed actingAs to return 200 instead of 201

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,4 +3,5 @@
 /.idea
 /.phpintel
 /.vscode
-.composer.lock
+composer.lock
+.phpunit.result.cache

--- a/src/Guards/GuardChecker.php
+++ b/src/Guards/GuardChecker.php
@@ -39,7 +39,7 @@ class GuardChecker
     public static function getGuardsProviders($guards)
     {
         return collect($guards)->mapWithKeys(function ($guard) {
-            return [GuardChecker::defaultGuardProvider($guard) => $guard];
+            return [self::defaultGuardProvider($guard) => $guard];
         });
     }
 

--- a/src/PassportMultiauth.php
+++ b/src/PassportMultiauth.php
@@ -16,7 +16,7 @@ class PassportMultiauth
      *
      * @param  \Illuminate\Contracts\Auth\Authenticatable $user
      * @param  array $scopes
-     * @return void
+     * @return \Illuminate\Contracts\Auth\Authenticatable
      * @throws Exception
      */
     public static function actingAs($user, $scopes = [])
@@ -35,11 +35,17 @@ class PassportMultiauth
 
         $user->withAccessToken($token);
 
+        if (isset($user->wasRecentlyCreated) && $user->wasRecentlyCreated) {
+            $user->wasRecentlyCreated = false;
+        }
+
         $guard = AuthConfigHelper::getUserGuard($user);
 
         app('auth')->guard($guard)->setUser($user);
 
         app('auth')->shouldUse($guard);
+
+        return $user;
     }
 
     /**


### PR DESCRIPTION
Closes #92 
Update package to be compatible with Laravel Passport [update](https://github.com/laravel/passport/pull/979/commits/4277d0b7c4d69721142b17fe0eb932688b126dea).

## Previous behavior

```php
$user = factory(User::class)->create();

PassportMultiauth::actingAs($user);

$response = $this->json('GET', '/user');

// 201
echo $response->getStatusCode();
```

## New behavior
```php
$user = factory(User::class)->create();

PassportMultiauth::actingAs($user);

$response = $this->json('GET', '/user');

// 200
echo $response->getStatusCode();
```