### PR TITLE
Added support for client_credentials grant type

### DIFF
--- a/src/Http/Middleware/AddCustomProvider.php
+++ b/src/Http/Middleware/AddCustomProvider.php
@@ -34,7 +34,7 @@ class AddCustomProvider
 
         $provider = $request->get('provider');
 
-        if ($this->invalidProvider($provider)) {
+        if ($this->invalidProvider($provider) || $this->clientGrantType($request)) {
             throw OAuthServerException::invalidRequest('provider');
         }
 
@@ -74,6 +74,15 @@ class AddCustomProvider
             if ($guardsConfiguration['provider'] === $provider) {
                 return false;
             }
+        }
+
+        return true;
+    }
+
+    protected function clientGrantType(Request $request)
+    {
+        if (!$request->has('client_credentials')) {
+            return false;
         }
 
         return true;

--- a/src/Http/Middleware/AddCustomProvider.php
+++ b/src/Http/Middleware/AddCustomProvider.php
@@ -81,7 +81,7 @@ class AddCustomProvider
 
     protected function clientGrantType(Request $request)
     {
-        if (!$request->has('client_credentials')) {
+        if (! $request->has('client_credentials')) {
             return false;
         }
 

--- a/tests/Feature/MultiauthTest.php
+++ b/tests/Feature/MultiauthTest.php
@@ -12,7 +12,7 @@ use SMartins\PassportMultiauth\Tests\Fixtures\Models\Company;
 
 class MultiauthTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -13,7 +13,7 @@ use SMartins\PassportMultiauth\Providers\MultiauthServiceProvider;
 
 abstract class TestCase extends BaseTestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/AddCustomProviderTest.php
+++ b/tests/Unit/AddCustomProviderTest.php
@@ -10,7 +10,7 @@ use SMartins\PassportMultiauth\Http\Middleware\AddCustomProvider;
 
 class AddCustomProviderTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -18,7 +18,7 @@ class AddCustomProviderTest extends TestCase
         config(['auth.guards.api.provider', 'users']);
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
     }
@@ -30,6 +30,7 @@ class AddCustomProviderTest extends TestCase
 
         $request = Mockery::mock(Request::class);
         $request->shouldReceive('get')->andReturn('companies')->with('provider');
+        $request->shouldReceive('has')->andReturn(false);
 
         $middleware = new AddCustomProvider();
         $middleware->handle($request, function () {
@@ -49,6 +50,7 @@ class AddCustomProviderTest extends TestCase
 
         $request = Mockery::mock(Request::class);
         $request->shouldReceive('get')->andReturn('not_found')->with('provider');
+        $request->shouldReceive('has')->andReturn(false);
 
         $middleware = new AddCustomProvider();
         $middleware->handle($request, function () {
@@ -62,6 +64,35 @@ class AddCustomProviderTest extends TestCase
 
         $request = Mockery::mock(Request::class);
         $request->shouldReceive('get')->andReturn(null)->with('provider');
+        $request->shouldReceive('has')->andReturn(false);
+
+        $middleware = new AddCustomProvider();
+        $middleware->handle($request, function () {
+            return 'response';
+        });
+    }
+
+    public function testPassClientCredentialsAndNoProvider()
+    {
+        $this->expectException(OAuthServerException::class);
+
+        $request = Mockery::mock(Request::class);
+        $request->shouldReceive('get')->andReturn(null)->with('provider');
+        $request->shouldReceive('has')->andReturn(true);
+
+        $middleware = new AddCustomProvider();
+        $middleware->handle($request, function () {
+            return 'response';
+        });
+    }
+
+    public function testDoNotPassNoClientCredentialsAndNoProvider()
+    {
+        $this->expectException(OAuthServerException::class);
+
+        $request = Mockery::mock(Request::class);
+        $request->shouldReceive('get')->andReturn(null)->with('provider');
+        $request->shouldReceive('has')->andReturn(false);
 
         $middleware = new AddCustomProvider();
         $middleware->handle($request, function () {

--- a/tests/Unit/AuthConfigHelperTest.php
+++ b/tests/Unit/AuthConfigHelperTest.php
@@ -11,7 +11,7 @@ use SMartins\PassportMultiauth\Exceptions\MissingConfigException;
 
 class AuthConfigHelperTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/HasApiTokensTest.php
+++ b/tests/Unit/HasApiTokensTest.php
@@ -10,7 +10,7 @@ use SMartins\PassportMultiauth\Exceptions\MissingConfigException;
 
 class HasApiTokensTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/MultiAuthenticateMiddlewareTest.php
+++ b/tests/Unit/MultiAuthenticateMiddlewareTest.php
@@ -16,7 +16,7 @@ class MultiAuthenticateMiddlewareTest extends TestCase
 {
     protected $auth;
 
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 
@@ -31,7 +31,7 @@ class MultiAuthenticateMiddlewareTest extends TestCase
         $this->auth = $this->app['auth'];
     }
 
-    public function tearDown()
+    public function tearDown(): void
     {
         Mockery::close();
 

--- a/tests/Unit/PassportMultiauthTest.php
+++ b/tests/Unit/PassportMultiauthTest.php
@@ -10,7 +10,7 @@ use SMartins\PassportMultiauth\Tests\Fixtures\Models\Customer;
 
 class PassportMultiauthTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/ProviderRepositoryTest.php
+++ b/tests/Unit/ProviderRepositoryTest.php
@@ -8,7 +8,7 @@ use SMartins\PassportMultiauth\ProviderRepository;
 
 class ProviderRepositoryTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 

--- a/tests/Unit/ServiceProviderTest.php
+++ b/tests/Unit/ServiceProviderTest.php
@@ -11,7 +11,7 @@ use SMartins\PassportMultiauth\Providers\MultiauthServiceProvider;
 
 class ServiceProviderTest extends TestCase
 {
-    public function setUp()
+    public function setUp(): void
     {
         parent::setUp();
 


### PR DESCRIPTION
Added void return type to tests methods `setUp` and `tearDown` to
match `Orchestra\Testbench\TestCase::setUp()` and
`Orchestra\Testbench\TestCase::tearDown()`.

Changed the `handle` method in the `AddCustomProvider` middleware to
override the `invalidProvider` call result when no provider is given
in the case of a `client_credentials` authentication request.

Added new tests in the `AddCustomProviderTest` class to test the new
cases.

Modified existing tests in the `AddCustomProviderTest` class to define use
of the `Request` class `has` method.