### PR TITLE
Compatibility Update

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,9 @@
     "prefer-stable": true,
     "require": {
         "php": "^7.2",
-        "laravel/passport": "^8.0"
+        "laravel/passport": "^8.0",
+        "nyholm/psr7": "^1.2.1",
+        "symfony/psr-http-message-bridge": "^2.0"
     },
     "require-dev": {
         "orchestra/testbench": "^4.0",

--- a/src/Facades/ServerRequest.php
+++ b/src/Facades/ServerRequest.php
@@ -2,7 +2,9 @@
 
 namespace SMartins\PassportMultiauth\Facades;
 
+use Nyholm\Psr7\Factory\Psr17Factory;
 use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\HttpFoundation\Request;
 
 class ServerRequest
@@ -14,6 +16,17 @@ class ServerRequest
      */
     public static function createRequest(Request $symfonyRequest)
     {
-        return (new DiactorosFactory())->createRequest($symfonyRequest);
+        if (class_exists(PsrHttpFactory::class)) {
+            $psr17Factory = new Psr17Factory;
+
+            return (new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory))
+                ->createRequest($symfonyRequest);
+        }
+
+        if (class_exists(DiactorosFactory::class)) {
+            return (new DiactorosFactory)->createRequest($symfonyRequest);
+        }
+
+        throw new Exception('Unable to resolve PSR request. Please install symfony/psr-http-message-bridge and nyholm/psr7.');
     }
 }

--- a/src/Facades/ServerRequest.php
+++ b/src/Facades/ServerRequest.php
@@ -3,16 +3,14 @@
 namespace SMartins\PassportMultiauth\Facades;
 
 use Nyholm\Psr7\Factory\Psr17Factory;
-use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 use Symfony\Component\HttpFoundation\Request;
 
 class ServerRequest
 {
     /**
-     * @todo Switch deprecated DiactorosFactory by PsrHttpFactory
      * @param Request $symfonyRequest
-     * @return \Psr\Http\Message\RequestInterface|\Psr\Http\Message\ServerRequestInterface|\Zend\Diactoros\ServerRequest
+     * @return \Psr\Http\Message\RequestInterface|\Psr\Http\Message\ServerRequestInterface
      */
     public static function createRequest(Request $symfonyRequest)
     {
@@ -21,10 +19,6 @@ class ServerRequest
 
             return (new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory))
                 ->createRequest($symfonyRequest);
-        }
-
-        if (class_exists(DiactorosFactory::class)) {
-            return (new DiactorosFactory)->createRequest($symfonyRequest);
         }
 
         throw new Exception('Unable to resolve PSR request. Please install symfony/psr-http-message-bridge and nyholm/psr7.');


### PR DESCRIPTION
This allows laravel 6.18+ / 7.x support. Replaces deprecated DiactorosFactory. Made downwards compatible, should the version installed have Diactoros instead.