### PR TITLE
Utilize Symfonys PSR Factory

### DIFF
--- a/src/Facades/ServerRequest.php
+++ b/src/Facades/ServerRequest.php
@@ -2,18 +2,32 @@
 
 namespace SMartins\PassportMultiauth\Facades;
 
-use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Exception;
 use Symfony\Component\HttpFoundation\Request;
+use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
+use Nyholm\Psr7\Factory\Psr17Factory;
+use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
 
 class ServerRequest
 {
     /**
-     * @todo Switch deprecated DiactorosFactory by PsrHttpFactory
+     * @todo Remove deprecated DiactorosFactory in favor of PsrHttpFactory
      * @param Request $symfonyRequest
      * @return \Psr\Http\Message\RequestInterface|\Psr\Http\Message\ServerRequestInterface|\Zend\Diactoros\ServerRequest
      */
     public static function createRequest(Request $symfonyRequest)
     {
-        return (new DiactorosFactory())->createRequest($symfonyRequest);
+        if (class_exists(PsrHttpFactory::class)) {
+            $psr17Factory = new Psr17Factory;
+
+            return (new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory))
+                ->createRequest($symfonyRequest);
+        }
+
+        if (class_exists(DiactorosFactory::class)) {
+            return (new DiactorosFactory)->createRequest($symfonyRequest);
+        }
+
+        throw new Exception('Unable to resolve PSR request. Please install symfony/psr-http-message-bridge and nyholm/psr7.');
     }
 }

--- a/src/Facades/ServerRequest.php
+++ b/src/Facades/ServerRequest.php
@@ -3,10 +3,10 @@
 namespace SMartins\PassportMultiauth\Facades;
 
 use Exception;
-use Symfony\Component\HttpFoundation\Request;
-use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Nyholm\Psr7\Factory\Psr17Factory;
+use Symfony\Bridge\PsrHttpMessage\Factory\DiactorosFactory;
 use Symfony\Bridge\PsrHttpMessage\Factory\PsrHttpFactory;
+use Symfony\Component\HttpFoundation\Request;
 
 class ServerRequest
 {

--- a/src/Facades/ServerRequest.php
+++ b/src/Facades/ServerRequest.php
@@ -17,7 +17,7 @@ class ServerRequest
      */
     public static function createRequest(Request $symfonyRequest)
     {
-        if (class_exists(PsrHttpFactory::class)) {
+        if (class_exists(Psr17Factory::class) && class_exists(PsrHttpFactory::class)) {
             $psr17Factory = new Psr17Factory;
 
             return (new PsrHttpFactory($psr17Factory, $psr17Factory, $psr17Factory, $psr17Factory))


### PR DESCRIPTION
This PR addresses https://github.com/sfelix-martins/passport-multiauth/issues/124

Laravel passport version 8.4.1 bumped [symfony/psr-http-message-bridge to version 2](https://github.com/laravel/passport/commit/0d9a007cbb814b8b6052200a969f209388fd3b04#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780L33) thus removing DiactorosFactory. Laravel Framework also [recommends version 2 since v7.0.0](https://github.com/laravel/framework/commit/2ef9367081875d1496b0de14e58ebca220c76b41#diff-b5d0ee8c97c7abd7e3fa29b9a27d1780L137)

This pull request is copy-paste from Laravel Framework [pull request](https://github.com/laravel/framework/pull/31018/files#diff-ae35d1c51db891ce72734de52c4b9f97L131) which is keeping backwards compatibility the same.

Tested with Laravel Framework 7.3.0 + Laravel Passport v8.4.3.